### PR TITLE
capitalize osnap correctly

### DIFF
--- a/components/Filter.tsx
+++ b/components/Filter.tsx
@@ -63,8 +63,12 @@ export function Filter({ className }: FilterProps) {
           <SelectGroup>
             <SelectLabel>Products</SelectLabel>
             {products.map((product) => (
-              <SelectItem className="capitalize" key={product} value={product}>
-                {product}
+              <SelectItem key={product} value={product}>
+                {product === "osnap" ? (
+                  <span>oSnap</span>
+                ) : (
+                  <span className="capitalize">{product}</span>
+                )}
               </SelectItem>
             ))}
           </SelectGroup>


### PR DESCRIPTION
## motivation

correctly capitalizes the `S` in oSnap.

<img width="864" alt="Screenshot 2024-07-24 at 12 05 17" src="https://github.com/user-attachments/assets/27205cfd-9132-4a4d-bc6f-eb5bdac8f973">
