### PR TITLE
improve search/filter ux

### DIFF
--- a/app/Subscribe.tsx
+++ b/app/Subscribe.tsx
@@ -40,7 +40,7 @@ export function Subscribe({ className }: Props) {
   return (
     <div
       className={cn(
-        " flex flex-col items-center justify-evenly p-4 text-center card",
+        "flex flex-col items-center justify-evenly p-4 text-center card",
         className,
       )}
     >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,12 +123,12 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
     );
   }
 
-  const isSearchResults = Object.keys(searchParams).length ? true : false;
+  const isSearchResults = Object.values(searchParams).length ? true : false;
 
   return (
     <>
       <div className="uppercase text-text-secondary font-light tracking-wider text-lg">
-        {isSearchResults ? "results" : "most recent articles"}
+        {isSearchResults ? "search results" : "most recent articles"}
       </div>
 
       <div className="grid grid-cols-5 gap-6 w-full">
@@ -139,7 +139,12 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
           key={posts.items[0].sys.id}
           post={posts.items[0]}
         />
-        <Subscribe className="col-span-5 @3xl:aspect-[1.2/1] self-auto @3xl:col-span-1" />
+        <Subscribe
+          className={cn([
+            "col-span-5 @3xl:aspect-[1.2/1] self-auto @3xl:col-span-1",
+            isSearchResults ? "hidden @3xl:flex" : "visible",
+          ])}
+        />
       </div>
 
       {posts.total > 1 ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,13 +123,17 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
     );
   }
 
-  const isSearchResults = Object.keys(searchParams).length;
+  const isSearchResults = Object.keys(searchParams).length ? true : false;
 
   return (
     <>
+      <div className="uppercase text-text-secondary font-light tracking-wider text-lg">
+        {isSearchResults ? "results" : "most recent articles"}
+      </div>
+
       <div className="grid grid-cols-5 gap-6 w-full">
         <Card
-          size="large"
+          size={isSearchResults ? "small" : "large"}
           className="col-span-5 @3xl:col-span-4"
           href={`/articles/${posts.items[0].fields.slug}`}
           key={posts.items[0].sys.id}
@@ -137,14 +141,13 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
         />
         <Subscribe className="col-span-5 @3xl:aspect-[1.2/1] self-auto @3xl:col-span-1" />
       </div>
+
       {posts.total > 1 ? (
         <>
-          <Divider />
-          <div className="uppercase text-text-secondary font-light tracking-wider text-md">
-            {isSearchResults ? "articles found" : "most recent articles"}
-          </div>
-
           <div className="w-full grid grid-cols-5 gap-6">
+            {!isSearchResults && (
+              <Divider className="col-span-5 @3xl:col-span-4" />
+            )}
             {posts.items.slice(1).map((post) => (
               <Card
                 className="col-span-5 @3xl:col-span-4"

--- a/components/Divider.tsx
+++ b/components/Divider.tsx
@@ -14,8 +14,8 @@ export function Divider({
       className={cn(
         "bg-border rounded-full",
         {
-          "w-auto h-[1px]": orientation === "horizontal",
-          "h-auto w-[1px]": orientation === "vertical",
+          "w-full h-[1px]": orientation === "horizontal",
+          "h-full w-[1px]": orientation === "vertical",
         },
         className,
       )}

--- a/components/Filter.tsx
+++ b/components/Filter.tsx
@@ -97,7 +97,7 @@ export function Filter({ className }: FilterProps) {
         )}
       </div>
       {tag && (
-        <div className="uppercase mt-2 text-xl text-text-secondary font-light tracking-wider ">
+        <div className="uppercase mt-2 text-sm text-text-secondary font-light tracking-wider">
           topic: <span className="text-text">{tag}</span>
         </div>
       )}

--- a/components/Filter.tsx
+++ b/components/Filter.tsx
@@ -27,59 +27,81 @@ export function Filter({ className }: FilterProps) {
   const {
     text,
     handleTextChange,
+    tag,
     productParam,
     handleProductChange,
     clearAll,
   } = useFilter();
+
+  // eslint-disable-next-line no-mixed-operators
+  const hasParams = (text || tag) ?? productParam ? true : false;
+
   return (
-    <div
-      className={cn("relative flex flex-col md:flex-row gap-2 py-4", className)}
-    >
-      <Input
-        aria-label="Full text search input field"
-        value={text}
-        onChange={(e) => {
-          handleTextChange(e.target.value);
-        }}
-        className="md:max-w-[320px]"
-        type="text"
-        placeholder="Search"
-      />
-      <Divider orientation="vertical" />
-      <Select
-        value={productParam}
-        key={productParam}
-        onValueChange={(prod) => {
-          handleProductChange(prod as UmaProducts);
-        }}
+    <div className="flex w-full flex-col gap-2 relative py-4">
+      <div
+        className={cn(
+          "relative flex-1 flex flex-col md:flex-row gap-2 ",
+          className,
+        )}
       >
-        <SelectTrigger
-          aria-label="Choose an UMA product to filter by."
-          className="w-full md:w-[180px] capitalize placeholder:font-light placeholder:text-text-secondary"
+        <Input
+          aria-label="Full text search input field"
+          value={text}
+          onChange={(e) => {
+            handleTextChange(e.target.value);
+          }}
+          className="md:max-w-[320px]"
+          type="text"
+          placeholder="Search"
+        />
+        <Divider orientation="vertical" />
+        <Select
+          value={productParam}
+          key={productParam}
+          onValueChange={(prod) => {
+            handleProductChange(prod as UmaProducts);
+          }}
         >
-          <SelectValue placeholder="Product" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>Products</SelectLabel>
-            {products.map((product) => (
-              <SelectItem className="capitalize" key={product} value={product}>
-                {product}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-      <Button
-        onClick={() => {
-          clearAll();
-        }}
-        className="flex uppercase text-text-secondary hover:text-text font-light items-center gap-4"
-        variant="outline"
-      >
-        clear
-        <Icon className="w-[1em] h-[1em] text-inherit" name="close-x" />
-      </Button>
+          <SelectTrigger
+            aria-label="Choose an UMA product to filter by."
+            className="w-full md:w-[180px] capitalize placeholder:font-light placeholder:text-text-secondary"
+          >
+            <SelectValue placeholder="Product" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>Products</SelectLabel>
+              {products.map((product) => (
+                <SelectItem
+                  className="capitalize"
+                  key={product}
+                  value={product}
+                >
+                  {product}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        {hasParams && (
+          <Button
+            onClick={() => {
+              clearAll();
+            }}
+            className="flex uppercase text-text-secondary hover:text-text font-light items-center gap-4"
+            variant="outline"
+          >
+            clear
+            <Icon className="w-[1em] h-[1em] text-inherit" name="close-x" />
+          </Button>
+        )}
+      </div>
+      {tag && (
+        <div className="uppercase mt-2 text-xl text-text-secondary font-light tracking-wider ">
+          topic: <span className="text-text">{tag}</span>
+        </div>
+      )}
+
       <Divider
         className="absolute w-[4000px] left-[calc(50%-2000px)] bottom-0"
         orientation="horizontal"

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -32,7 +32,7 @@ export type BadgeProps = React.HTMLAttributes<HTMLDivElement> &
     href?: string;
   };
 
-function Badge({ className, variant, href, ...props }: BadgeProps) {
+function Badge({ className, variant, role, href, ...props }: BadgeProps) {
   if (href) {
     return (
       <Link type="internal" href={href}>
@@ -44,7 +44,10 @@ function Badge({ className, variant, href, ...props }: BadgeProps) {
     );
   }
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <div
+      className={cn(badgeVariants({ variant, role: "display" }), className)}
+      {...props}
+    />
   );
 }
 

--- a/hooks/useFilter.ts
+++ b/hooks/useFilter.ts
@@ -28,6 +28,12 @@ export function useFilter() {
     });
   }
 
+  function handleTagChange(value: string) {
+    setParams({
+      tag: value,
+    });
+  }
+
   const clearAll = useCallback(() => {
     setText("");
     removeParams(["product", "search", "tag"]);
@@ -37,6 +43,8 @@ export function useFilter() {
     text,
     handleTextChange,
     productParam: params.product,
+    tag: params.tag,
+    handleTagChange,
     handleProductChange,
     clearAll,
   };


### PR DESCRIPTION
## motivation

The filter UX is a bit confusing. This PR improves the experience by doing a few things:

- Display a topic if a tag has been selected
- The search results view now looks very different from the home page (most recent articles) view
- The clear button is only visible if the filter is being used.

The user is now more aware that they are seeing a filtered list and by which topic if one has been selected.

## screenshots

### home page (recent articles)
<img width="980" alt="Screenshot 2024-07-24 at 13 25 34" src="https://github.com/user-attachments/assets/9c65d48e-374c-4169-b9aa-1ceee2ed6747">

### search results page
<img width="1000" alt="Screenshot 2024-07-24 at 13 48 05" src="https://github.com/user-attachments/assets/ccd75b95-f833-4234-87a0-32d7f3f1f3fa">
