### PR TITLE
Minor updates

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,27 +6,12 @@ import { Subscribe } from "./Subscribe";
 import { ButtonScrollTo } from "@/components/ButtonScrollTo";
 import { Filter } from "@/components/Filter";
 import { Suspense } from "react";
-import {
-  canPaginatePrevious,
-  getPaginationControlLink,
-  getPreviousPaginationLink,
-  getPaginationPages,
-  getNextPaginationLink,
-  canPaginateNext,
-  getVisiblePageNumbers,
-} from "@/lib/pagination";
+import { getPaginationPages, getLimitFromSearchParams } from "@/lib/pagination";
 
 import { Metadata } from "next";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { createCacheKey, cn } from "@/lib/utils";
 import { SITE_BASE_URL } from "@/constants/site";
+import { PaginationControls } from "@/components/PaginationControls";
 
 export type SearchParams = Record<string, string | undefined>;
 
@@ -105,12 +90,6 @@ type PostsProps = {
 async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
   const posts = await getBlogEntries(draftModeEnabled, searchParams);
 
-  const pageDetails = {
-    totalPosts: posts.total,
-    pathname: "/",
-    searchParams,
-  };
-
   if (!posts.total) {
     return (
       <h2 className="my-auto flex-1 text-text-secondary text-2xl">
@@ -121,8 +100,8 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
 
   const isSearchResults = Object.values(searchParams).length ? true : false;
   const currentPage = parseInt(searchParams.page ?? "1");
-  const totalPages = getPaginationPages(posts.total);
-  const visiblePages = getVisiblePageNumbers(currentPage, totalPages);
+  const limit = getLimitFromSearchParams(searchParams);
+  const totalPages = getPaginationPages(posts.total, limit);
 
   return (
     <>
@@ -164,43 +143,15 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
         </>
       ) : null}
 
-      <Pagination>
-        <PaginationContent>
-          <PaginationItem>
-            <PaginationPrevious
-              disabled={!canPaginatePrevious(pageDetails)}
-              className={cn({
-                "opacity-40": !canPaginatePrevious(pageDetails),
-              })}
-              href={getPreviousPaginationLink(pageDetails)}
-            />
-          </PaginationItem>
-          {visiblePages.map((pageNum) => (
-            <PaginationItem key={pageNum}>
-              <PaginationLink
-                isActive={currentPage === pageNum}
-                href={getPaginationControlLink({
-                  ...pageDetails,
-                  paginationControl: {
-                    page: pageNum,
-                  },
-                })}
-              >
-                {pageNum}
-              </PaginationLink>
-            </PaginationItem>
-          ))}
-          <PaginationItem>
-            <PaginationNext
-              disabled={!canPaginateNext(pageDetails)}
-              className={cn({
-                "opacity-40": !canPaginateNext(pageDetails),
-              })}
-              href={getNextPaginationLink(pageDetails)}
-            />
-          </PaginationItem>
-        </PaginationContent>
-      </Pagination>
+      {posts.total > 0 && (
+        <PaginationControls
+          totalPosts={posts.total}
+          pathname="/"
+          searchParams={searchParams}
+          currentPage={currentPage}
+          totalPages={totalPages}
+        />
+      )}
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import {
   getPaginationPages,
   getNextPaginationLink,
   canPaginateNext,
+  getVisiblePageNumbers,
 } from "@/lib/pagination";
 
 import { Metadata } from "next";
@@ -119,6 +120,9 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
   }
 
   const isSearchResults = Object.values(searchParams).length ? true : false;
+  const currentPage = parseInt(searchParams.page ?? "1");
+  const totalPages = getPaginationPages(posts.total);
+  const visiblePages = getVisiblePageNumbers(currentPage, totalPages);
 
   return (
     <>
@@ -164,32 +168,31 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
+              disabled={!canPaginatePrevious(pageDetails)}
               className={cn({
                 "opacity-40": !canPaginatePrevious(pageDetails),
               })}
               href={getPreviousPaginationLink(pageDetails)}
             />
           </PaginationItem>
-          {Array.from({ length: getPaginationPages(posts.total) }).map(
-            (_, i) => (
-              <PaginationItem key={i}>
-                <PaginationLink
-                  isActive={parseInt(searchParams.page ?? "1") === i + 1}
-                  href={getPaginationControlLink({
-                    ...pageDetails,
-                    paginationControl: {
-                      page: i + 1,
-                    },
-                  })}
-                >
-                  {i + 1}
-                </PaginationLink>
-              </PaginationItem>
-            ),
-          )}
-
+          {visiblePages.map((pageNum) => (
+            <PaginationItem key={pageNum}>
+              <PaginationLink
+                isActive={currentPage === pageNum}
+                href={getPaginationControlLink({
+                  ...pageDetails,
+                  paginationControl: {
+                    page: pageNum,
+                  },
+                })}
+              >
+                {pageNum}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
           <PaginationItem>
             <PaginationNext
+              disabled={!canPaginateNext(pageDetails)}
               className={cn({
                 "opacity-40": !canPaginateNext(pageDetails),
               })}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -40,7 +40,7 @@ const textBoxVariants = cva(
 );
 
 const rootVariants = cva(
-  "group card shadow-md hover:border-text transition-colors gap-6 p-4 @2xl:p-5",
+  "group card shadow-md hover:border-text/25 transition-colors gap-6 p-4 @2xl:p-5",
   {
     variants: {
       size: {

--- a/components/PaginationControls.tsx
+++ b/components/PaginationControls.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PostsPerPageSelect } from "./PostsPerPageSelect";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+  canPaginatePrevious,
+  getPaginationControlLink,
+  getPreviousPaginationLink,
+  getNextPaginationLink,
+  canPaginateNext,
+  getVisiblePageNumbers,
+} from "@/lib/pagination";
+import { cn } from "@/lib/utils";
+import { SearchParams } from "@/app/page";
+import { UmaBlogEntries } from "@/lib/contentful";
+
+type PaginationControlsProps = {
+  totalPosts: UmaBlogEntries["total"];
+  pathname: string;
+  searchParams: SearchParams;
+  currentPage: number;
+  totalPages: number;
+  className?: string;
+};
+
+export function PaginationControls({
+  totalPosts,
+  pathname,
+  searchParams,
+  currentPage,
+  totalPages,
+  className,
+}: PaginationControlsProps) {
+  const visiblePages = getVisiblePageNumbers(currentPage, totalPages, 5);
+
+  const pageDetails = {
+    totalPosts,
+    pathname,
+    searchParams,
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-between gap-4 mt-6 w-full",
+        className,
+      )}
+    >
+      <PostsPerPageSelect />
+
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              disabled={!canPaginatePrevious(pageDetails)}
+              className={cn({
+                "opacity-40": !canPaginatePrevious(pageDetails),
+              })}
+              href={getPreviousPaginationLink(pageDetails)}
+            />
+          </PaginationItem>
+          {visiblePages.map((pageNum) => (
+            <PaginationItem key={pageNum}>
+              <PaginationLink
+                isActive={currentPage === pageNum}
+                href={getPaginationControlLink({
+                  ...pageDetails,
+                  paginationControl: {
+                    page: pageNum,
+                    limit: searchParams.limit,
+                  },
+                })}
+              >
+                {pageNum}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+          <PaginationItem>
+            <PaginationNext
+              disabled={!canPaginateNext(pageDetails)}
+              className={cn({
+                "opacity-40": !canPaginateNext(pageDetails),
+              })}
+              href={getNextPaginationLink(pageDetails)}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}

--- a/components/PaginationControls.tsx
+++ b/components/PaginationControls.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { PostsPerPageSelect } from "./PostsPerPageSelect";
 import {
   Pagination,
@@ -39,7 +38,7 @@ export function PaginationControls({
   totalPages,
   className,
 }: PaginationControlsProps) {
-  const visiblePages = getVisiblePageNumbers(currentPage, totalPages, 5);
+  const visiblePages = getVisiblePageNumbers(currentPage, totalPages);
 
   const pageDetails = {
     totalPosts,

--- a/components/PostsPerPageSelect.tsx
+++ b/components/PostsPerPageSelect.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const POST_LIMIT_OPTIONS = [
+  { value: "5", label: "5 posts" },
+  { value: "10", label: "10 posts" },
+  { value: "20", label: "20 posts" },
+  { value: "50", label: "50 posts" },
+  { value: "all", label: "Show all" },
+];
+
+export function PostsPerPageSelect() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const currentLimit = searchParams.get("limit") ?? "10"; // Default to 10
+
+  const handleValueChange = (value: string) => {
+    const params = new URLSearchParams(searchParams);
+
+    // Reset to page 1 when changing limit
+    params.delete("page");
+
+    if (value === "all") {
+      params.set("limit", "all");
+    } else {
+      params.set("limit", value);
+    }
+
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor="posts-per-page"
+        className="text-sm text-text-secondary whitespace-nowrap"
+      >
+        Posts per page:
+      </label>
+      <Select value={currentLimit} onValueChange={handleValueChange}>
+        <SelectTrigger id="posts-per-page" className="w-[120px] h-9">
+          <SelectValue placeholder="Select" />
+        </SelectTrigger>
+        <SelectContent>
+          {POST_LIMIT_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/components/PostsPerPageSelect.tsx
+++ b/components/PostsPerPageSelect.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { DEFAULT_PAGINATION_LIMIT } from "@/lib/pagination";
 
 const POST_LIMIT_OPTIONS = [
   { value: "5", label: "5 posts" },
@@ -22,7 +23,8 @@ export function PostsPerPageSelect() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const currentLimit = searchParams.get("limit") ?? "10"; // Default to 10
+  const currentLimit =
+    searchParams.get("limit") ?? String(DEFAULT_PAGINATION_LIMIT);
 
   const handleValueChange = (value: string) => {
     const params = new URLSearchParams(searchParams);

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -36,6 +36,7 @@ const PaginationItem = React.forwardRef<
 PaginationItem.displayName = "PaginationItem";
 
 type PaginationLinkProps = {
+  disabled?: boolean;
   isActive?: boolean;
   className?: string;
 } & Pick<ButtonProps, "size"> &
@@ -68,7 +69,13 @@ const PaginationPrevious = ({
   <PaginationLink
     aria-label="Go to previous page"
     size="default"
-    className={cn("gap-1 pl-2.5", className)}
+    className={cn(
+      "gap-1 pl-2.5",
+      {
+        "pointer-events-none": props.disabled,
+      },
+      className,
+    )}
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
@@ -84,7 +91,13 @@ const PaginationNext = ({
   <PaginationLink
     aria-label="Go to next page"
     size="default"
-    className={cn("gap-1 pr-2.5", className)}
+    className={cn(
+      "gap-1 pr-2.5",
+      {
+        "pointer-events-none": props.disabled,
+      },
+      className,
+    )}
     {...props}
   >
     <span>Next</span>

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -62,11 +62,10 @@ function addPaginationControls(searchParams: SearchParams) {
 }
 
 export async function getAllBlogEntries() {
-  const MAX_BATCH_SIZE = 10; // maximum num of posts we can fetch per request from contentful
+  const MAX_BATCH_SIZE = 1000; // maximum num of posts we can fetch per request from contentful
   let skip = 0;
   let hasMoreEntries = true;
 
-  // Store all entries
   const allItems = [];
   let totalItems = 0;
 
@@ -88,16 +87,13 @@ export async function getAllBlogEntries() {
     allItems.push(...response.items);
     totalItems = response.total;
 
-    // If we got fewer items than our batch size, we've reached the end
     if (response.items.length < MAX_BATCH_SIZE) {
       hasMoreEntries = false;
     } else {
-      // Prepare for the next batch
       skip += MAX_BATCH_SIZE;
     }
   }
 
-  // Create response object with the same shape as Contentful's response
   return {
     items: allItems,
     includes: {},

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -61,18 +61,50 @@ function addPaginationControls(searchParams: SearchParams) {
   };
 }
 
-// TODO: currently the max we can fetch is 1000 entries with one request. Add logic to batch requests IF there are more than 1000 entries in total.
 export async function getAllBlogEntries() {
-  const options = {
-    content_type: contentType,
-    "fields.content[exists]": true, // no empty posts
-    order: "-fields.publishDate", // sorted latest first
-    limit: 1000, // max limit
+  const MAX_BATCH_SIZE = 10; // maximum num of posts we can fetch per request from contentful
+  let skip = 0;
+  let hasMoreEntries = true;
+
+  // Store all entries
+  const allItems = [];
+  let totalItems = 0;
+
+  // Keep fetching batches until we get fewer items than our batch size
+  while (hasMoreEntries) {
+    const options = {
+      content_type: contentType,
+      "fields.content[exists]": true,
+      order: "-fields.publishDate",
+      limit: MAX_BATCH_SIZE,
+      skip,
+    } as const;
+
+    const response =
+      await productionClient.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>(
+        options,
+      );
+
+    allItems.push(...response.items);
+    totalItems = response.total;
+
+    // If we got fewer items than our batch size, we've reached the end
+    if (response.items.length < MAX_BATCH_SIZE) {
+      hasMoreEntries = false;
+    } else {
+      // Prepare for the next batch
+      skip += MAX_BATCH_SIZE;
+    }
+  }
+
+  // Create response object with the same shape as Contentful's response
+  return {
+    items: allItems,
+    includes: {},
+    total: totalItems,
+    limit: MAX_BATCH_SIZE,
     skip: 0,
-  } as const;
-  return productionClient.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>(
-    options,
-  );
+  };
 }
 
 export const getBlogEntries = async (

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -9,7 +9,7 @@ import { documentToPlainTextString } from "@contentful/rich-text-plain-text-rend
 import { Document } from "@contentful/rich-text-types";
 import { createClient } from "contentful";
 import words from "lodash.words";
-import { PAGINATION_LIMIT } from "./pagination";
+import { getLimitFromSearchParams } from "./pagination";
 
 const contentType = "blogPost";
 
@@ -50,14 +50,24 @@ function addTagFilter(searchParams: SearchParams) {
 
 function addPaginationControls(searchParams: SearchParams) {
   const { page } = searchParams;
+  const limit = getLimitFromSearchParams(searchParams);
+
+  // If showing all posts, don't use pagination
+  if (limit === "all") {
+    return {
+      limit: 1000, // Use a large number to get all posts
+      skip: 0,
+    };
+  }
+
   if (typeof page === "string") {
     return {
-      limit: PAGINATION_LIMIT,
-      skip: (parseInt(page) - 1) * PAGINATION_LIMIT,
+      limit,
+      skip: (parseInt(page) - 1) * limit,
     };
   }
   return {
-    limit: PAGINATION_LIMIT,
+    limit,
   };
 }
 

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -4,6 +4,9 @@ import { UmaBlogEntries } from "./contentful";
 // Default limit if not specified
 export const DEFAULT_PAGINATION_LIMIT = 10;
 
+// Default number of pagination links to show
+export const DEFAULT_VISIBLE_PAGES = 5;
+
 type ControlOptions = {
   pathname: string;
   searchParams: SearchParams;
@@ -143,7 +146,7 @@ export function getPaginationPages(
 export function getVisiblePageNumbers(
   currentPage: number,
   totalPages: number,
-  maxVisible = 4, // max number that actually looks good on mobile
+  maxVisible = DEFAULT_VISIBLE_PAGES, // max number that actually looks good on mobile
 ): number[] {
   if (totalPages <= maxVisible) {
     return Array.from({ length: totalPages }, (_, i) => i + 1);

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,8 +1,8 @@
 import { SearchParams } from "@/app/page";
 import { UmaBlogEntries } from "./contentful";
 
-// TODO: let user set limit
-export const PAGINATION_LIMIT = 10;
+// Default limit if not specified
+export const DEFAULT_PAGINATION_LIMIT = 10;
 
 type ControlOptions = {
   pathname: string;
@@ -10,7 +10,7 @@ type ControlOptions = {
   totalPosts: UmaBlogEntries["total"];
   paginationControl: {
     page: number;
-    // limit: number;
+    limit?: string;
   };
 };
 
@@ -27,8 +27,25 @@ export function getPaginationControlLink({
   } else {
     newParams.set("page", encodeURIComponent(paginationControl.page));
   }
-  // newParams.set("limit", encodeURIComponent(paginationControl.limit));
+
+  if (paginationControl.limit) {
+    newParams.set("limit", encodeURIComponent(paginationControl.limit));
+  }
+
   return `${pathname}?${newParams.toString()}`;
+}
+
+export function getLimitFromSearchParams(
+  searchParams: SearchParams,
+): number | "all" {
+  const newParams = new URLSearchParams(searchParams as ParamsWithValues);
+  const limitAsString = newParams.get("limit");
+
+  if (limitAsString === "all") {
+    return "all";
+  }
+
+  return limitAsString ? parseInt(limitAsString) : DEFAULT_PAGINATION_LIMIT;
 }
 
 export function canPaginatePrevious({
@@ -53,8 +70,14 @@ export function canPaginateNext({
   const newParams = new URLSearchParams(searchParams as ParamsWithValues);
   const pageAsString = newParams.get("page");
   const pageAsInt = pageAsString ? parseInt(pageAsString) : 1;
+  const limit = getLimitFromSearchParams(searchParams);
 
-  return pageAsInt < Math.ceil(totalPosts / PAGINATION_LIMIT);
+  // If showing all posts, there's only one page
+  if (limit === "all") {
+    return false;
+  }
+
+  return pageAsInt < Math.ceil(totalPosts / limit);
 }
 
 export function getPreviousPaginationLink({
@@ -65,6 +88,8 @@ export function getPreviousPaginationLink({
   const newParams = new URLSearchParams(searchParams as ParamsWithValues);
   const pageAsString = newParams.get("page");
   const pageAsInt = pageAsString ? parseInt(pageAsString) : 1;
+  const limitParam = newParams.get("limit") ?? undefined;
+
   if (canPaginatePrevious({ searchParams })) {
     return getPaginationControlLink({
       totalPosts,
@@ -72,6 +97,7 @@ export function getPreviousPaginationLink({
       searchParams,
       paginationControl: {
         page: pageAsInt - 1,
+        limit: limitParam,
       },
     });
   }
@@ -86,6 +112,7 @@ export function getNextPaginationLink({
   const newParams = new URLSearchParams(searchParams as ParamsWithValues);
   const pageAsString = newParams.get("page");
   const pageAsInt = pageAsString ? parseInt(pageAsString) : 1;
+  const limitParam = newParams.get("limit") ?? undefined;
 
   if (canPaginateNext({ searchParams, totalPosts })) {
     return getPaginationControlLink({
@@ -94,6 +121,7 @@ export function getNextPaginationLink({
       searchParams,
       paginationControl: {
         page: pageAsInt + 1,
+        limit: limitParam,
       },
     });
   }
@@ -102,8 +130,12 @@ export function getNextPaginationLink({
 
 export function getPaginationPages(
   totalPosts: UmaBlogEntries["total"],
+  limit: number | "all" = DEFAULT_PAGINATION_LIMIT,
 ): number {
-  return Math.ceil(totalPosts / PAGINATION_LIMIT);
+  if (limit === "all") {
+    return 1;
+  }
+  return Math.ceil(totalPosts / limit);
 }
 
 // ensures we only display a max number of pagination links.

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -105,3 +105,27 @@ export function getPaginationPages(
 ): number {
   return Math.ceil(totalPosts / PAGINATION_LIMIT);
 }
+
+// ensures we only display a max number of pagination links.
+// keeps the current page's index 1 away from the end
+export function getVisiblePageNumbers(
+  currentPage: number,
+  totalPages: number,
+  maxVisible = 4, // max number that actually looks good on mobile
+): number[] {
+  if (totalPages <= maxVisible) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  let startPage: number;
+
+  if (currentPage <= Math.ceil(maxVisible / 2)) {
+    startPage = 1;
+  } else if (currentPage > totalPages - Math.floor(maxVisible / 2)) {
+    startPage = totalPages - maxVisible + 1;
+  } else {
+    startPage = currentPage - Math.floor(maxVisible / 2);
+  }
+
+  return Array.from({ length: maxVisible }, (_, i) => startPage + i);
+}


### PR DESCRIPTION
Some maintenance updates:

- Add ability to let user choose number of posts per page.
- Show fewer pagination control links since this is overflowing on smaller screens.
- Support >1000 posts. contenteful API only responds with a max of 1000 posts, so we batch these calls until we reach our posts limit.