### PR TITLE
fix: default to https if protocol missing

### DIFF
--- a/components/RichText/RenderDocumentText.tsx
+++ b/components/RichText/RenderDocumentText.tsx
@@ -16,9 +16,9 @@ import { isExternal } from "../Link";
 import { IframeContainer } from "./IframeContainer";
 import { Code } from "./Code";
 import { Video } from "./Video";
+import { addDefaultProtocol } from "@/lib/utils";
 
 // Map text-format types to custom components
-
 const markRenderers: RenderMark = {
   [MARKS.BOLD]: (text) => <strong>{text}</strong>,
   [MARKS.ITALIC]: (text) => <em>{text}</em>,
@@ -30,7 +30,7 @@ const markRenderers: RenderMark = {
 
 const nodeRenderers: RenderNode = {
   [INLINES.HYPERLINK]: (node, children) => {
-    const href = node.data.uri as string;
+    const href = addDefaultProtocol(node.data.uri as string);
     if (
       href.includes("youtube.com/embed") ||
       href.includes("player.vimeo.com") ||

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -24,6 +24,12 @@ export const previewClient = createClient({
   host: "preview.contentful.com",
 });
 
+type BlogEntryItem = Awaited<
+  ReturnType<
+    typeof productionClient.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>
+  >
+>["items"][number];
+
 function addProductFilter(searchParams: SearchParams) {
   const product = searchParams.product;
   if (product && typeof product === "string") {
@@ -76,7 +82,7 @@ export async function getAllBlogEntries() {
   let skip = 0;
   let hasMoreEntries = true;
 
-  const allItems = [];
+  const allItems: BlogEntryItem[] = [];
   let totalItems = 0;
 
   // Keep fetching batches until we get fewer items than our batch size

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -1,17 +1,24 @@
 import { env } from "@/app/env";
-import { exec } from "child_process";
+import { execSync } from "child_process";
+
+const typesDir = "types/contentful";
 
 // fetch schema from our space and generate types
-const command = `cf-content-types-generator -s ${env.SPACE_ID} -t ${env.CMA_TOKEN} -X -g -o types/contentful`;
+const generateCommand = `cf-content-types-generator -s ${env.SPACE_ID} -t ${env.CMA_TOKEN} -X -g -o ${typesDir}`;
 
-exec(command, (error, stdout, stderr) => {
-  if (error) {
+try {
+  // build interfaces
+  execSync(generateCommand, { encoding: "utf-8" });
+  // fix lint issues, convert to types
+  execSync(`npx eslint --fix "${typesDir}/**/*.ts"`, { encoding: "utf-8" });
+  // format
+  execSync(
+    `npx prettier --write "${typesDir}/**/*.ts" --config ./prettier.config.mjs`,
+    { encoding: "utf-8" },
+  );
+} catch (error) {
+  if (error instanceof Error) {
     console.error(`Error: ${error.message}`);
-    return;
   }
-  if (stderr) {
-    console.error(`CLI Error: ${stderr}`);
-    return;
-  }
-  console.log(`CLI Output: ${stdout}`);
-});
+  process.exit(1);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,3 +41,27 @@ export function toCSSIdentifier(fileName: string) {
 
   return cssIdentifier;
 }
+
+/**
+ * Ensures external links use HTTPS. Rewrites http:// to https:// and adds https://
+ * if missing. Preserves relative links (starting with "/") for NextLink.
+ *
+ * @param uri - URI from Contentful (may be missing protocol or have http://)
+ * @returns URI with HTTPS protocol, or unchanged if relative
+ */
+export function addDefaultProtocol(uri: string): string {
+  // handle in-app relative links
+  if (uri.startsWith("/")) {
+    return uri;
+  }
+  // Rewrite http:// to https:// for security
+  if (uri.startsWith("http://")) {
+    return uri.replace("http://", "https://");
+  }
+
+  if (!uri.startsWith("https://")) {
+    return `https://${uri}`;
+  }
+
+  return uri;
+}

--- a/types/contentful/TypeAcrossBlogPost.ts
+++ b/types/contentful/TypeAcrossBlogPost.ts
@@ -11,6 +11,9 @@ export type TypeAcrossBlogPostFields = {
   content: EntryFieldTypes.RichText;
   featuredImage: EntryFieldTypes.AssetLink;
   tag?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
+  slug?: EntryFieldTypes.Symbol;
+  publishDate: EntryFieldTypes.Date;
+  description: EntryFieldTypes.Symbol;
 };
 
 export type TypeAcrossBlogPostSkeleton = EntrySkeletonType<

--- a/types/contentful/TypeYouTubeVideo.ts
+++ b/types/contentful/TypeYouTubeVideo.ts
@@ -1,0 +1,29 @@
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
+
+export type TypeYouTubeVideoFields = {
+  youtubeVideo?: EntryFieldTypes.Object;
+};
+
+export type TypeYouTubeVideoSkeleton = EntrySkeletonType<
+  TypeYouTubeVideoFields,
+  "youTubeVideo"
+>;
+export type TypeYouTubeVideo<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode = LocaleCode,
+> = Entry<TypeYouTubeVideoSkeleton, Modifiers, Locales>;
+
+export function isTypeYouTubeVideo<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+>(
+  entry: Entry<EntrySkeletonType, Modifiers, Locales>,
+): entry is TypeYouTubeVideo<Modifiers, Locales> {
+  return entry.sys.contentType.sys.id === "youTubeVideo";
+}

--- a/types/contentful/index.ts
+++ b/types/contentful/index.ts
@@ -36,3 +36,9 @@ export type {
 } from "./TypeTestContent";
 export { isTypeUmip } from "./TypeUmip";
 export type { TypeUmip, TypeUmipFields, TypeUmipSkeleton } from "./TypeUmip";
+export { isTypeYouTubeVideo } from "./TypeYouTubeVideo";
+export type {
+  TypeYouTubeVideo,
+  TypeYouTubeVideoFields,
+  TypeYouTubeVideoSkeleton,
+} from "./TypeYouTubeVideo";


### PR DESCRIPTION
For blog links:
- `http` => `https` (security)
- `app.across.to` => `https://app.across.to` (missing protocol)
- `/blog/some-blog-title` (internal links remain unchanged)

Included in this PR is a type fix and an additional step that will run the linter and formatter on generated type files