### PR TITLE
chore: reduce Contentful load from bot-driven ISR cache misses

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { getBlogEntries } from "@/lib/contentful";
 import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
 import { Card } from "@/components/Card";
 import { Divider } from "@/components/Divider";
 import { Subscribe } from "./Subscribe";
@@ -18,6 +19,14 @@ export type SearchParams = Record<string, string | undefined>;
 type PageProps = {
   searchParams: SearchParams;
 };
+
+const ALLOWED_SEARCH_PARAMS = [
+  "page",
+  "search",
+  "tag",
+  "product",
+  "limit",
+] as const;
 
 // TODO: get proper copy for this
 const title = "UMA Blog";
@@ -52,6 +61,28 @@ export const revalidate = 1800; // 30 minutes
 
 export default function Home({ searchParams }: PageProps) {
   const { isEnabled } = draftMode();
+
+  // Strip unknown query params back to the canonical URL so bot-poisoned
+  // URLs (e.g. /?utm_source=foo, /?cb=12345) don't blow up the ISR
+  // cache-key surface. Each unique URL is a separate ISR entry, so without
+  // this any crawler with creative parameters could mint unbounded misses.
+  const hasUnknownParams = Object.keys(searchParams).some(
+    (key) =>
+      !ALLOWED_SEARCH_PARAMS.includes(
+        key as (typeof ALLOWED_SEARCH_PARAMS)[number],
+      ),
+  );
+  if (hasUnknownParams) {
+    const cleanParams = new URLSearchParams();
+    for (const key of ALLOWED_SEARCH_PARAMS) {
+      const value = searchParams[key];
+      if (typeof value === "string" && value.length > 0) {
+        cleanParams.set(key, value);
+      }
+    }
+    const qs = cleanParams.toString();
+    redirect(qs ? `/?${qs}` : "/");
+  }
 
   // set a key for the async post component to reset state when URL changes.
   // this way we can always show the loading state when fetching data
@@ -104,6 +135,21 @@ async function Posts({ draftModeEnabled, searchParams }: PostsProps) {
   const currentPage = parseInt(searchParams.page ?? "1");
   const limit = getLimitFromSearchParams(searchParams);
   const totalPages = getPaginationPages(posts.total, limit);
+
+  // Bots probing /?page=99999 would otherwise mint a fresh ISR entry for
+  // every out-of-range page. Send them to the canonical first page (or to
+  // / if no other filters are set) so the cache surface stays bounded.
+  if (currentPage > totalPages) {
+    const cleanParams = new URLSearchParams();
+    for (const key of ["search", "tag", "product", "limit"] as const) {
+      const value = searchParams[key];
+      if (typeof value === "string" && value.length > 0) {
+        cleanParams.set(key, value);
+      }
+    }
+    const qs = cleanParams.toString();
+    redirect(qs ? `/?${qs}` : "/");
+  }
 
   return (
     <>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { SITE_BASE_URL } from "@/constants/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // Block crawlers from minting unbounded ISR cache keys via
+        // `?search=*`, `?tag=*`, `?page=*`, `?product=*`, `?utm_*`, etc.
+        // The canonical `/` listing and every `/articles/[slug]` URL stay
+        // crawlable, and individual articles are listed in the sitemap.
+        disallow: "/?",
+      },
+    ],
+    sitemap: `${SITE_BASE_URL}/sitemap.xml`,
+    host: SITE_BASE_URL,
+  };
+}

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow:
-
-Sitemap: https://blog.uma.xyz/sitemap.xml

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -9,6 +9,7 @@ import { documentToPlainTextString } from "@contentful/rich-text-plain-text-rend
 import { Document } from "@contentful/rich-text-types";
 import { createClient } from "contentful";
 import words from "lodash.words";
+import { cache } from "react";
 import { getLimitFromSearchParams } from "./pagination";
 
 const contentType = "blogPost";
@@ -138,7 +139,11 @@ export const getBlogEntries = async (
   );
 };
 
-export async function getBlogPostBySlug(
+// Wrapped in React `cache()` so generateMetadata and the page render
+// dedupe to a single Contentful call per request. The contentful SDK uses
+// axios (not fetch), so Next.js's automatic request memoization doesn't
+// kick in — `cache()` is what does the dedup here.
+export const getBlogPostBySlug = cache(async function getBlogPostBySlug(
   slug: UmaBlogEntry["fields"]["slug"],
   isDraft: boolean,
 ) {
@@ -153,7 +158,7 @@ export async function getBlogPostBySlug(
       options,
     );
   return entries.total ? entries.items[0] : undefined;
-}
+});
 
 // gets 3 most related articles based on topic tags
 export async function getRelatedPosts(


### PR DESCRIPTION
## Summary

UMA blog turned out to be ~22% of total Contentful CDA volume on the shared space — confirmed by SDK fingerprint (`contentful 10.9.2 + Node 20`) and by being the only consumer of `content_type=blogPost`, the highest-frequency single query in support's report. Most of that volume is ISR cache misses from crawlers hitting parameterized listing URLs.

This PR closes the same three gaps we just fixed in [across.to#135](https://github.com/across-protocol/across.to/pull/135) and the [dapp PR](https://github.com/across-protocol/dapp/pull/277):

## What changed

- **robots.txt → robots.ts.** The static `app/robots.txt` was empty (`Disallow:`) and pointed at the wrong host (`blog.uma.xyz` while `SITE_BASE_URL` is `uma.blog.xyz`). New `app/robots.ts` disallows `/?` so crawlers can't probe `/?search=*`, `/?tag=*`, `/?product=*`, `/?page=*`, `/?utm_*`, or anything else with query strings on the root. Articles at `/articles/[slug]` and the canonical `/` remain crawlable, and the dynamic sitemap continues to give Google a deterministic discovery path.
- **Listing page param hardening.** `app/page.tsx` now whitelists `page`, `search`, `tag`, `product`, `limit` — anything else triggers a redirect to the canonical URL. Out-of-range `?page=N` redirects to the first page. Together these prevent bots from minting unbounded ISR cache entries.
- **Per-request dedup on `getBlogPostBySlug`.** Wrapped in React `cache()`. The contentful SDK at `^10.9.2` uses axios, so Next.js's automatic fetch dedup doesn't apply — both `generateMetadata` and the page component were independently hitting Contentful for the same slug. Cuts article-page renders from 3 Contentful calls to 2.

## Why now

Contentful support flagged limit pressure on the shared space; the across.to fix is in flight. The CSV showed `content_type=blogPost&fields.content[exists]=true&limit=10&order=-fields.publishDate` (164 calls — exact match for `getBlogEntries` with default args) as the single most-requested query, plus 1774 calls overall for this app. With ISR already in place (`revalidate = 1800` on `/`), the leak is unique URL variants forcing cache misses, not the canonical render itself.

## Test plan

- [ ] `pnpm build` succeeds locally (verified — `/robots.txt` and `/sitemap.xml` show as static routes in the build output).
- [ ] `curl https://<deploy>/robots.txt` shows `Disallow: /?` and the correct `Sitemap:` reference.
- [ ] Visiting `/?utm_source=foo` (or any unknown param) 307-redirects to `/`.
- [ ] Visiting `/?page=99999` redirects to `/` (or to the canonical filtered URL if other filters are set).
- [ ] `/articles/<slug>` still renders correctly with metadata, image, and related articles.
- [ ] Sitemap still serves from the dynamic `app/sitemap.ts` and lists every published article.
- [ ] Contentful CDA call rate drops within a couple of revalidate cycles after deploy.

## Related

- [across-protocol/across.to#135](https://github.com/across-protocol/across.to/pull/135) — same fix on the across.to marketing site
- [across-protocol/dapp#277](https://github.com/across-protocol/dapp/pull/277) — dapp-side equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)